### PR TITLE
Add support for proxy configuration

### DIFF
--- a/src/main/java/capsule/DependencyManager.java
+++ b/src/main/java/capsule/DependencyManager.java
@@ -8,6 +8,8 @@
  */
 package capsule;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,13 +17,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import static java.util.Collections.unmodifiableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.AbstractForwardingRepositorySystemSession;
 import org.eclipse.aether.ConfigurationProperties;
@@ -40,6 +42,8 @@ import org.eclipse.aether.graph.DependencyVisitor;
 import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -126,7 +130,14 @@ public class DependencyManager {
             RepositoryPolicy releasePolicy = maketReleasePolicy(r);
             RepositoryPolicy snapshotPolicy = allowSnapshots ? maketSnapshotPolicy(r) : new RepositoryPolicy(false, null, null);
 
-            final RemoteRepository repo = createRepo(r, releasePolicy, snapshotPolicy);
+            RemoteRepository repo = createRepo(r, releasePolicy, snapshotPolicy);
+            ProxySelector selector = getSession().getProxySelector();
+            Proxy proxy = selector.getProxy(repo);
+            if( proxy != null ) {
+                if( isLogging(LOG_DEBUG)) log(LOG_DEBUG, String.format("Setting proxy: '%s' for dependency: %s", proxy, repo));
+                repo = new RemoteRepository.Builder(repo).setProxy(proxy).build();
+            }
+
             if (!rs.contains(repo))
                 rs.add(repo);
         }

--- a/src/main/java/capsule/DependencyManager.java
+++ b/src/main/java/capsule/DependencyManager.java
@@ -187,7 +187,8 @@ public class DependencyManager {
 
         s.setLocalRepositoryManager(system.newLocalRepositoryManager(s, localRepo));
 
-        s.setProxySelector(settings.getProxySelector());
+        SystemProxySelector sysProxySelector = new SystemProxySelector(logLevel);
+        s.setProxySelector(sysProxySelector.isValid() ? sysProxySelector : settings.getProxySelector());
         s.setMirrorSelector(settings.getMirrorSelector());
         s.setAuthenticationSelector(settings.getAuthSelector());
 

--- a/src/main/java/capsule/SystemProxySelector.java
+++ b/src/main/java/capsule/SystemProxySelector.java
@@ -1,0 +1,195 @@
+package capsule;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.repository.DefaultProxySelector;
+
+/**
+ * A proxy selector that uses proxy configuration defined
+ * in the system environment configuration and Java
+ * system properties.
+ *
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public class SystemProxySelector implements ProxySelector {
+
+    private static final int LOG_NONE = 0;
+    private static final int LOG_QUIET = 1;
+    private static final int LOG_VERBOSE = 2;
+    private static final int LOG_DEBUG = 3;
+    private static final String LOG_PREFIX = "CAPSULE: ";
+    private final int logLevel;
+
+
+    private final DefaultProxySelector target = new DefaultProxySelector();
+
+    private final Map<String,String> env;
+
+    private final Properties props;
+
+    private int count;
+
+    /**
+     * Create a proxy selector object looking for proxy settings in the environment
+     * configurations and the Java system properties. It checks the following properties:
+     *
+     * <li>http.proxyHost (Java system property) </li>
+     * <li>https.proxyHost (Java system property) </li>
+     * <li>http_proxy (environment variable)</li>
+     * <li>https_proxy (environment variable)</li>
+     * <li>HTTP_PROXY (environment variable)</li>
+     * <li>HTTPS_PROXY (environment variable)</li>
+     *
+     * @param logLevel Capsule logging level
+     */
+    public SystemProxySelector( int logLevel ) {
+        this( System.getenv(), System.getProperties(), logLevel);
+    }
+
+    SystemProxySelector( Map env, Properties props, int logLevel ) {
+        this.env = env;
+        this.props = props;
+        this.logLevel = logLevel;
+        init();
+    }
+
+    @Override
+    public Proxy getProxy(RemoteRepository repository) {
+        return target.getProxy(repository);
+    }
+
+    protected void init() {
+
+        addProxyFromProperties("http");
+        addProxyFromProperties("https");
+
+        addProxyFromEnv("http");
+        addProxyFromEnv("https");
+
+        addProxyFromEnv("HTTP");
+        addProxyFromEnv("HTTPS");
+    }
+
+
+    protected void addProxyFromEnv( String type ) {
+        checkValidProtocol(type);
+
+        String key = type + ( isUpper(type) ? "_PROXY" : "_proxy");
+        String[] items = parseProxy( env.get(key), "http".equals(type) ? "80":"443" );
+        if( items == null ) {
+            return;
+        }
+
+        String noProxy = env.get( isUpper(type) ? "NO_PROXY" : "no_proxy" );
+
+        Proxy proxy = new Proxy(type.toLowerCase(), items[0], Integer.parseInt(items[1]) );
+        target.add(proxy, noProxy);
+        count++;
+
+        // dump proxy information to logger
+        if( isLogging(LOG_VERBOSE) )
+            log(logLevel, String.format("Adding `%s` proxy: %s [from system environment]", type, proxy));
+
+    }
+
+    protected void addProxyFromProperties( String type ) {
+        checkValidProtocol(type);
+
+        String host = props.getProperty(type + ".proxyHost");
+        if( host == null || host.isEmpty() ) {
+            // nothing to do
+            return ;
+        }
+
+        String port = props.getProperty(type + ".proxyPort");
+        if( port == null || port.isEmpty() ) {
+            port = "http".equals(type) ? "80" : "443";
+        }
+
+        Proxy proxy = new Proxy(type, host, Integer.parseInt(port));
+        String nonProxy = props.getProperty(type + ".nonProxyHosts");
+
+        // append this proxy to the target selector
+        target.add(proxy, nonProxy);
+        count++;
+
+        // dump proxy information to logger
+        if( isLogging(LOG_VERBOSE) )
+            log(logLevel, String.format("Adding `%s` proxy: %s [from Java system properties]", type, proxy));
+    }
+
+    /**
+     * Given a proxy URL returns a two element arrays containing the host name and the port
+     *
+     * @param url The proxy host URL.
+     * @param defPort The default proxy port
+     * @return An array containing the host name and the proxy port or null when url is empty
+     */
+    static String[] parseProxy( String url, String defPort ) {
+        String[] result = new String[2];
+
+        if( url==null || url.isEmpty() ) {
+            return null;
+        }
+
+        int p = url.indexOf("://");
+        if( p != -1 ) {
+
+            url = url.substring(p+3);
+        }
+
+        if( (p=url.indexOf(':')) != -1 ) {
+            result[0] = url.substring(0,p);
+            result[1] = url.substring(p+1);
+        }
+        else {
+            result[0] = url;
+            result[1] = defPort;
+        }
+
+        return result;
+    }
+
+
+    /**
+     * @return The number of defined proxy
+     */
+    int getCount() {
+        return count;
+    }
+
+    /**
+     * @return {@code true} if the selector defines at least one proxy server
+     */
+    public boolean isValid() { return count>0; }
+
+    private boolean isUpper( String str ) {
+        for( int i=0; i<str.length(); i++ ) {
+            if( Character.isLowerCase(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected final boolean isLogging(int level) {
+        return level <= logLevel;
+    }
+
+    protected final void log(int level, String str) {
+        if (isLogging(level))
+            System.err.println(LOG_PREFIX + str);
+    }
+
+    protected void checkValidProtocol( String protocol ) {
+        if( "http".equalsIgnoreCase(protocol) ) return;
+        if( "https".equalsIgnoreCase(protocol) ) return;
+        throw new IllegalArgumentException(String.format("Illegal proxy protocol: '%s'", protocol));
+    }
+
+}

--- a/src/main/java/capsule/SystemProxySelector.java
+++ b/src/main/java/capsule/SystemProxySelector.java
@@ -93,7 +93,7 @@ public class SystemProxySelector implements ProxySelector {
 
         // dump proxy information to logger
         if( isLogging(LOG_VERBOSE) )
-            log(logLevel, String.format("Adding `%s` proxy: %s [from system environment]", type, proxy));
+            log(LOG_VERBOSE, String.format("Adding `%s` proxy: %s [from system environment]", type, proxy));
 
     }
 
@@ -120,7 +120,7 @@ public class SystemProxySelector implements ProxySelector {
 
         // dump proxy information to logger
         if( isLogging(LOG_VERBOSE) )
-            log(logLevel, String.format("Adding `%s` proxy: %s [from Java system properties]", type, proxy));
+            log(LOG_VERBOSE, String.format("Adding `%s` proxy: %s [from Java system properties]", type, proxy));
     }
 
     /**

--- a/src/test/java/capsule/SystemProxySelectorTest.java
+++ b/src/test/java/capsule/SystemProxySelectorTest.java
@@ -1,0 +1,151 @@
+package capsule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Test;
+
+/**
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public class SystemProxySelectorTest {
+
+    @Test
+    public void testProxyWithEnvProperties() {
+
+        Map<String,String> env = new HashMap<>();
+        env.put("http_proxy", "my.proxy.com:8080");
+        env.put("https_proxy", "secure.proxy.com:8888");
+
+        SystemProxySelector selector = new SystemProxySelector(env, new Properties(), 2);
+        assertEquals(2, selector.getCount());
+
+        RemoteRepository repo = new RemoteRepository.Builder("bar",null,"https://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        Proxy proxy = selector.getProxy(repo);
+        assertEquals("https", proxy.getType());
+        assertEquals("secure.proxy.com", proxy.getHost());
+        assertEquals(8888, proxy.getPort());
+
+        repo = new RemoteRepository.Builder("bar",null,"http://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        proxy = selector.getProxy(repo);
+        assertEquals("http", proxy.getType());
+        assertEquals("my.proxy.com", proxy.getHost());
+        assertEquals(8080, proxy.getPort());
+    }
+
+
+    @Test
+    public void testProxyWithEnvPropertiesAndDefaultPorts() {
+
+        Map<String,String> env = new HashMap<>();
+        env.put("http_proxy", "http://my.proxy.com");
+        env.put("https_proxy", "https://secure.proxy.com");
+
+        SystemProxySelector selector = new SystemProxySelector(env, new Properties(), 0);
+        assertEquals(2, selector.getCount());
+
+        RemoteRepository repo = new RemoteRepository.Builder("bar",null,"https://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        Proxy proxy = selector.getProxy(repo);
+        assertEquals("https", proxy.getType());
+        assertEquals("secure.proxy.com", proxy.getHost());
+        assertEquals(443, proxy.getPort());
+
+        repo = new RemoteRepository.Builder("bar",null,"http://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        proxy = selector.getProxy(repo);
+        assertEquals("http", proxy.getType());
+        assertEquals("my.proxy.com", proxy.getHost());
+        assertEquals(80, proxy.getPort());
+    }
+
+    @Test
+    public void testProxyWithEnvPropertiesAndNoProxyHosts() {
+
+        Map<String,String> env = new HashMap<>();
+        env.put("http_proxy", "http://my.proxy.com");
+        env.put("https_proxy", "https://secure.proxy.com");
+        env.put("no_proxy", "*.foo.com|localhost");
+
+        SystemProxySelector selector = new SystemProxySelector(env, new Properties(), 2);
+        assertEquals(2, selector.getCount());
+
+        RemoteRepository repo = new RemoteRepository.Builder("bar",null,"http://localhost/service/foo-bar-0.14.3.jar").build();
+        Proxy proxy = selector.getProxy(repo);
+        assertNull(proxy);
+
+        RemoteRepository repo2 = new RemoteRepository.Builder("bar",null,"https://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        Proxy proxy2 = selector.getProxy(repo2);
+        assertEquals("https", proxy2.getType());
+        assertEquals("secure.proxy.com", proxy2.getHost());
+        assertEquals(443, proxy2.getPort());
+
+    }
+
+
+    @Test
+    public void testProxySystemPropertiesWithDefaultPorts() {
+
+        Properties props = new Properties();
+        props.setProperty("http.proxyHost", "foo.host.name");
+        props.setProperty("https.proxyHost", "secure.host.name");
+
+        SystemProxySelector selector = new SystemProxySelector(new HashMap(), props, 0);
+        assertEquals(2, selector.getCount());
+
+        RemoteRepository repo = new RemoteRepository.Builder("bar",null,"https://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        Proxy proxy = selector.getProxy(repo);
+        assertEquals("https", proxy.getType());
+        assertEquals("secure.host.name", proxy.getHost());
+        assertEquals(443, proxy.getPort());
+
+        repo = new RemoteRepository.Builder("bar",null,"http://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        proxy = selector.getProxy(repo);
+        assertEquals("http", proxy.getType());
+        assertEquals("foo.host.name", proxy.getHost());
+        assertEquals(80, proxy.getPort());
+    }
+
+
+    @Test
+    public void testProxySystemPropertiesWithCustomPorts() {
+
+        // environment conf
+        Map<String,String> env = new HashMap<>();
+        env.put("http_proxy", "env1.proxy.com:8080");
+        env.put("https_proxy", "env2.secure.com:8888");
+
+        // system properties
+        Properties props = new Properties();
+        props.setProperty("http.proxyHost", "prop1.host.name");
+        props.setProperty("http.proxyPort", "8081");
+        props.setProperty("https.proxyHost", "prop2.secure.name");
+        props.setProperty("https.proxyPort", "9091");
+
+
+        // it must use the proxy defined in the system properties
+        // because it is supposed to override the one defined with environment variables
+
+        SystemProxySelector selector = new SystemProxySelector(env, props, 2);
+        assertEquals(4, selector.getCount());
+
+        RemoteRepository repo = new RemoteRepository.Builder("bar",null,"https://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        Proxy proxy = selector.getProxy(repo);
+        assertEquals("https", proxy.getType());
+        assertEquals("prop2.secure.name", proxy.getHost());
+        assertEquals(9091, proxy.getPort());
+
+        repo = new RemoteRepository.Builder("bar",null,"http://oss.sonatype.org/service/foo-bar-0.14.3.jar").build();
+        proxy = selector.getProxy(repo);
+        assertEquals("http", proxy.getType());
+        assertEquals("prop1.host.name", proxy.getHost());
+        assertEquals(8081, proxy.getPort());
+    }
+
+
+
+}


### PR DESCRIPTION
Currently Maven caplet is reading the `settings.xml` for was not applying the proxy setting that were defined in it. 

Also this pull request check for the defined by the following standard Linux environment variables: 
- http_proxy
- https_proxy
- HTTP_PROXY
- HTTPS_PROXY

and the standard Java [proxy system properties](http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html)" 
- http.proxyHost
- http.proxyPort
- https.proxyHost
- https.proxyPort
