### PR TITLE
Add support for HTTP/HTTPS proxy authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ configurations {
     }
         
     all*.exclude group: 'org.eclipse.sisu', module: '*'
-    all*.exclude group: 'commons-codec', module: '*'
 }
 
 dependencies {
@@ -111,6 +110,7 @@ shadowJar {
     exclude 'javax/inject/**'
     exclude 'org/apache/log4j/lf5/**'
     exclude 'org/apache/log4j/xml/log4j.dtd'
+    exclude 'org/apache/commons/codec/language/**'
     exclude '**/version.properties'
 
     relocate 'org.', 'capsule.org.'


### PR DESCRIPTION
As I was experimenting with Maven Capsules, I noticed that proxy support was added in #4 but lacked support for authentication. This PR fixes that. Tests are updated accordingly. 

Environment variable-based proxy URLs can now be:

```
http(s)://username:password@myproxy.org:80
```

System properties `http.proxyUser`, `http.proxyPassword`, `https.proxyUser` and `https.proxyPassword` are also supported.

Note that some `commons-codec` classes are now included in the shadow jar as basic authentication uses them, notably `org.apache.commons.codec.binary.Base64`.

 I'm not very used to Gradle so please double-check the small modifications i've done to the `build.gradle` file.

Otherwise thanks for this awesome library. Hope this helps!
