### PR TITLE
Accept comma as separator in no_proxy env variable

### DIFF
--- a/src/main/java/capsule/SystemProxySelector.java
+++ b/src/main/java/capsule/SystemProxySelector.java
@@ -84,6 +84,9 @@ public class SystemProxySelector implements ProxySelector {
 
         String noProxy = env.get(isUpper(type) ? "NO_PROXY" : "no_proxy");
 
+        if (noProxy != null)
+            noProxy = noProxy.replace(',', '|');
+
         Proxy proxy;
         if (credentials != null) {
             AuthenticationBuilder authenticationBuilder = new AuthenticationBuilder();

--- a/src/test/java/capsule/SystemProxySelectorTest.java
+++ b/src/test/java/capsule/SystemProxySelectorTest.java
@@ -68,7 +68,7 @@ public class SystemProxySelectorTest {
         Map<String, String> env = new HashMap<>();
         env.put("http_proxy", "http://my.proxy.com");
         env.put("https_proxy", "https://secure.proxy.com");
-        env.put("no_proxy", "*.foo.com|localhost");
+        env.put("no_proxy", "*.foo.com,localhost");
 
         SystemProxySelector selector = new SystemProxySelector(env, new Properties(), 2);
         assertEquals(2, selector.getCount());


### PR DESCRIPTION
The current proxy code only accepts pipes as separators in the no_proxy environment variable. The comma should be accepted as it is widely used.

This PR replaces any comma in the no_proxy environment variable by a pipe which is the separator required by Aether.
